### PR TITLE
Add asset precompilation

### DIFF
--- a/lib/roda/opal_assets.rb
+++ b/lib/roda/opal_assets.rb
@@ -51,13 +51,19 @@ class Roda
 
     def stylesheet file, media: :all
       file << '.css' unless file.end_with? '.css'
-      asset = sprockets[file]
 
-      if asset.nil?
-        raise "File not found: #{file}.css"
-      end
+      path = if production?
+               "/assets/#{manifest[file]}"
+             else
+               asset = sprockets[file]
 
-      path = asset.filename.to_s.sub(Dir.pwd, '')
+               if asset.nil?
+                 raise "File not found: #{file}.css"
+               end
+
+               asset.filename.to_s.sub(Dir.pwd, '')
+             end
+
       %{<link href="#{path}" media="#{media}" rel="stylesheet" />}
     end
 

--- a/lib/roda/opal_assets.rb
+++ b/lib/roda/opal_assets.rb
@@ -1,3 +1,4 @@
+require "yaml"
 require "roda/opal_assets/version"
 require "roda"
 require "opal"

--- a/roda-opal_assets.gemspec
+++ b/roda-opal_assets.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "opal", "~> 0.9", "< 0.11.0"
+  spec.add_runtime_dependency "opal", "~> 0.7", "< 0.11.0"
   spec.add_runtime_dependency "sprockets", "~> 3.6.0"
   spec.add_runtime_dependency "roda"
   spec.add_runtime_dependency "uglifier", "~> 3.0"
+  spec.add_runtime_dependency "rack", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/roda-opal_assets.gemspec
+++ b/roda-opal_assets.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "opal", "~> 0.9", "< 0.12.0"
+  spec.add_runtime_dependency "opal", "~> 0.9", "< 0.11.0"
+  spec.add_runtime_dependency "sprockets", "~> 3.6.0"
   spec.add_runtime_dependency "roda"
   spec.add_runtime_dependency "uglifier", "~> 3.0"
 


### PR DESCRIPTION
Currently, no asset precompilation is supported. Assets are lazily compiled in production, but Sprockets asset compilation is not thread-safe, so if two requests come in hot at the same time after a fresh deploy, one of them is going to take multiple seconds and the other is going to fail. This PR fixes both of those scenarios by allowing precompilation.

In order to allow asset precompilation, you simply need to add a Rake task to your app:

``` ruby
desc 'Compile Ruby assets'
task 'assets:precompile' do
  assets = Roda::OpalAssets.new(env: 'production')
  assets << 'app.js' << 'app.css' << 'whatever_else.rb'
  assets.build
end
```

The call to `assets.build` kicks off writing assets to `public/assets/` and adds an `assets.yml` manifest to the current directory that maps asset names to files on disk.

Also, this PR adds support for Opal all the way back to 0.7. It got a bit messy, though. I should probably clean it up some.
